### PR TITLE
Fix upload limit fallback for invalid configuration

### DIFF
--- a/src/files/files.service.spec.ts
+++ b/src/files/files.service.spec.ts
@@ -120,6 +120,33 @@ describe('FilesService', () => {
       );
     });
 
+    it('should fall back to default limit when MAX_UPLOAD_MB is invalid', async () => {
+      const invalidConfigService = {
+        get: jest.fn((key: string, defaultValue?: string) => {
+          if (key === 'MAX_UPLOAD_MB') {
+            return 'not-a-number';
+          }
+          if (key === 'ALLOWED_MIME_LIST') {
+            return 'image/png,image/jpeg,application/pdf';
+          }
+          if (key === 'UPLOADS_DIR') {
+            return './uploads';
+          }
+          return defaultValue as string;
+        }),
+      } as unknown as ConfigService;
+
+      const serviceWithInvalidConfig = new FilesService(repository, invalidConfigService);
+      const largeFile = { ...mockFile, size: 26 * 1024 * 1024 }; // 26MB
+
+      await expect(serviceWithInvalidConfig.uploadFile(largeFile)).rejects.toThrow(
+        BadRequestException
+      );
+      await expect(serviceWithInvalidConfig.uploadFile(largeFile)).rejects.toThrow(
+        'File size exceeds limit of 25MB'
+      );
+    });
+
     it('should handle MIME types case-insensitively', async () => {
       const mockAdd = jest.spyOn(repository, 'add').mockResolvedValue();
       jest.spyOn(fs, 'mkdir').mockResolvedValue(undefined);

--- a/src/files/files.service.ts
+++ b/src/files/files.service.ts
@@ -18,7 +18,9 @@ export class FilesService {
     private readonly filesRepository: FilesRepository,
     private readonly configService: ConfigService,
   ) {
-    this.maxUploadMB = parseInt(this.configService.get<string>('MAX_UPLOAD_MB', '25'));
+    const rawMaxUpload = this.configService.get<string>('MAX_UPLOAD_MB', '25');
+    const parsedMaxUpload = Number(rawMaxUpload);
+    this.maxUploadMB = Number.isFinite(parsedMaxUpload) && parsedMaxUpload > 0 ? parsedMaxUpload : 25;
     this.allowedMimeTypes = this.configService
       .get<string>('ALLOWED_MIME_LIST', 'image/png,image/jpeg,application/pdf')
       .split(',')


### PR DESCRIPTION
## Summary
- ensure the files service falls back to the default upload size limit when MAX_UPLOAD_MB is invalid
- add a regression test covering invalid MAX_UPLOAD_MB configuration

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cdd2059ab88320902428c5ea8b1707