### PR TITLE
Fix: Correct Filename Truncation Logic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "prettier": "^3.0.0",
         "source-map-support": "^0.5.21",
         "supertest": "^7.0.0",
-        "ts-jest": "^29.1.0",
+        "ts-jest": "^29.4.4",
         "ts-loader": "^9.4.3",
         "ts-node": "^10.9.1",
         "tsconfig-paths": "^4.2.0",
@@ -10566,9 +10566,9 @@
       }
     },
     "node_modules/ts-jest": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.1.tgz",
-      "integrity": "sha512-SaeUtjfpg9Uqu8IbeDKtdaS0g8lS6FT6OzM3ezrDfErPJPHNDo/Ey+VFGP1bQIDfagYDLyRpd7O15XpG1Es2Uw==",
+      "version": "29.4.4",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.4.tgz",
+      "integrity": "sha512-ccVcRABct5ZELCT5U0+DZwkXMCcOCLi2doHRrKy1nK/s7J7bch6TzJMsrY09WxgUUIP/ITfmcDS8D2yl63rnXw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "prettier": "^3.0.0",
     "source-map-support": "^0.5.21",
     "supertest": "^7.0.0",
-    "ts-jest": "^29.1.0",
+    "ts-jest": "^29.4.4",
     "ts-loader": "^9.4.3",
     "ts-node": "^10.9.1",
     "tsconfig-paths": "^4.2.0",

--- a/src/files/utils/sanitize-filename.util.spec.ts
+++ b/src/files/utils/sanitize-filename.util.spec.ts
@@ -1,0 +1,74 @@
+import { sanitizeFilename } from './sanitize-filename.util';
+
+describe('sanitizeFilename', () => {
+  it('should remove path traversal attempts', () => {
+    expect(sanitizeFilename('../../../etc/passwd')).toBe('etcpasswd');
+  });
+
+  it('should remove slashes', () => {
+    expect(sanitizeFilename('a/b\\c')).toBe('abc');
+  });
+
+  it('should remove dangerous characters', () => {
+    expect(sanitizeFilename('a<b:c"d>e|f?g*h')).toBe('abcdefgh');
+  });
+
+  it('should remove control characters', () => {
+    expect(sanitizeFilename('a\x00b\x1fc')).toBe('abc');
+  });
+
+  it('should normalize Unicode characters', () => {
+    // \u00e9 is the acute e, which is a single character
+    // \u0065\u0301 is the same character, but composed of two parts
+    const composed = '\u00e9'; // é
+    const decomposed = '\u0065\u0301'; // e + ´
+    expect(sanitizeFilename(decomposed)).toBe(composed);
+  });
+
+  it('should collapse and trim spaces', () => {
+    expect(sanitizeFilename('  a  b  ')).toBe('a_b');
+  });
+
+  it('should replace spaces with underscores', () => {
+    expect(sanitizeFilename('a b c')).toBe('a_b_c');
+  });
+
+  it('should remove leading and trailing dots', () => {
+    expect(sanitizeFilename('.a.b.')).toBe('a.b');
+  });
+
+  it('should throw an error for empty or invalid input', () => {
+    expect(() => sanitizeFilename('')).toThrow('Filename must be a non-empty string');
+    expect(() => sanitizeFilename(null as any)).toThrow('Filename must be a non-empty string');
+    expect(() => sanitizeFilename(undefined as any)).toThrow('Filename must be a non-empty string');
+  });
+
+  it('should throw an error if filename becomes empty after sanitization', () => {
+    expect(() => sanitizeFilename('..')).toThrow('Filename becomes empty after sanitization');
+  });
+
+  describe('length truncation', () => {
+    const longString = 'a'.repeat(150);
+    const longStringWithExt = 'b'.repeat(118) + '.ext';
+
+    it('should truncate a long filename without an extension', () => {
+      const sanitized = sanitizeFilename(longString, 120);
+      expect(sanitized.length).toBe(120);
+    });
+
+    it('should truncate a long filename and preserve the extension', () => {
+      const sanitized = sanitizeFilename(longStringWithExt);
+      expect(sanitized).toBe('b'.repeat(116) + '.ext');
+      expect(sanitized.length).toBe(120);
+    });
+
+    // This is the failing test case for the bug
+    it('should handle truncation when the extension is longer than the max length', () => {
+        const maxLength = 10;
+        const originalName = 'short.verylongextension'; // length > 10
+        const sanitized = sanitizeFilename(originalName, maxLength);
+        expect(sanitized.length).toBeLessThanOrEqual(maxLength);
+        expect(sanitized.startsWith('.')).toBe(false);
+    });
+  });
+});

--- a/src/files/utils/sanitize-filename.util.ts
+++ b/src/files/utils/sanitize-filename.util.ts
@@ -3,7 +3,7 @@
  * Follows PM requirements: anti-path-traversal, Unicode normalization, length limits
  */
 
-export function sanitizeFilename(filename: string): string {
+export function sanitizeFilename(filename: string, maxLength = 120): string {
   if (!filename || typeof filename !== 'string') {
     throw new Error('Filename must be a non-empty string');
   }
@@ -26,13 +26,18 @@ export function sanitizeFilename(filename: string): string {
   // 4. Replace spaces with underscores for URL safety
   sanitized = sanitized.replace(/\s/g, '_');
 
-  // 5. Limit length (120 chars max as per PM spec)
-  if (sanitized.length > 120) {
-    const extension = sanitized.includes('.') 
-      ? '.' + sanitized.split('.').pop() 
+  // 5. Limit length (maxLength chars max as per PM spec)
+  if (sanitized.length > maxLength) {
+    const extension = sanitized.includes('.')
+      ? '.' + sanitized.split('.').pop()
       : '';
-    const nameOnly = sanitized.substring(0, 120 - extension.length);
-    sanitized = nameOnly + extension;
+
+    if (extension.length > maxLength) {
+      sanitized = sanitized.substring(0, maxLength);
+    } else {
+      const nameOnly = sanitized.substring(0, maxLength - extension.length);
+      sanitized = nameOnly + extension;
+    }
   }
 
   // 6. Ensure we still have a valid filename


### PR DESCRIPTION
This pull request fixes a bug in the `sanitizeFilename` utility where filenames with long extensions were not truncated correctly, potentially exceeding the specified maximum length. The fix ensures that all sanitized filenames adhere to the length limit. A new test suite for the `sanitizeFilename` utility has also been added to verify the fix and improve test coverage.

---
*PR created automatically by Jules for task [9731543632171396046](https://jules.google.com/task/9731543632171396046) started by @Metraplox*